### PR TITLE
TNDO-1272 Fix npm dependencies

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -10,7 +10,7 @@ case $1 in
         export CMD="mvn -B org.codehaus.mojo:license-maven-plugin:download-licenses -U"
         ;;
     npm)
-        export CMD="npm-license-checker"
+        export CMD="/node_modules/license-checker/bin/license-checker --json > dependencies.json"
         ;;
 esac
 


### PR DESCRIPTION
The script npm-license-checker does a hard coded changedir into the folder /source.
There is nothing when running the action, so we do not use the script.