### PR TITLE
adjusted docker run command for pivio client

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -22,4 +22,4 @@ echo $DOCKER_HUB_PASSWORD | docker login -u $DOCKER_HUB_USERNAME --password-stdi
 (docker run --rm \
   -v $(pwd):/app/cloud-beta/source-project \
   leanix/microservice-intelligence-pivio-client \
-  run_cicd_pivio --host int.leanix.net --token $INT_LEANIX_NET_MICROSERVICES_API_TOKEN --file source-project/pivio.yaml) || true
+  python pivio.py run_cicd_pivio --host int.leanix.net --token $EU_LEANIX_NET_MICROSERVICES_API_TOKEN --file source-project/pivio.yaml) || true


### PR DESCRIPTION
I referenced the environment variable EU_LEANIX_NET_MICROSERVICES_API_TOKEN to send the ldif to the new workspace. Please create this secret with an API token for https://eu.leanix.net/leanixMicroserviceIntelligence

Also now using CMD instead of ENTRYPOINT. That's why the command had to change. 