### PR TITLE
LIXC-964 Add Maven and Node.js/npm to Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,12 @@
 FROM ubuntu:latest
 
+ENV DEBIAN_FRONTEND=noninteractive 
+
 RUN apt-get update -yq && \
     apt-get upgrade -yq && \
     apt-get install -yq curl && \
+    apt-get install -yq maven && \
+    apt-get install -yq nodejs npm && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/*
 


### PR DESCRIPTION
The debianfrontend stuff is needed because of this issue which appeared:
https://askubuntu.com/questions/909277/avoiding-user-interaction-with-tzdata-when-installing-certbot-in-a-docker-contai