### PR TITLE
Unset JAVA_HOME which leads to conflicts executing mvn

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -25,6 +25,10 @@ curl -X POST https://demo-eu.leanix.net/services/cicd-connector/v1/metadata \
 
 if [[ -f "pom.xml" ]]; then
   echo "Mvn repository detected"
+  
+  unset JAVA_HOME 
+  unset JAVA_HOME_11.0.8_x64 
+
   mvn org.codehaus.mojo:license-maven-plugin:download-licenses
   curl -X POST \
     'https://demo-eu.leanix.net/services/cicd-connector/v1/dependencies?source=mvn&externalId='$INPUT_SERVICENAME \


### PR DESCRIPTION
Looks like that during the build process for Java projects, the Java home variable is set.
This usually happen with the action actions/setup-java@v1.3.0.

This variable is also set by the Github Actions environment when the Docker container for microservice-intelligence-action is run, so the Github Actions environment just passes all its environment variables along.

This variable is incorrect for the Docker container, so I hope/think that unsetting it, will most likely help.

I can't test this locally, because as Ralf has already commented, just starting up the container locally, everything works fine. So it can only be verified in the actually build environment ... I vote for just merging and see what happens (I can't get worse ;-))